### PR TITLE
Fix default tag type

### DIFF
--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -108,7 +108,7 @@ defmodule Logger.Backends.Gelf do
     level           = Keyword.get(config, :level)
     metadata        = Keyword.get(config, :metadata, [])
     compression     = Keyword.get(config, :compression, :gzip)
-    tags            = Keyword.get(config, :tags, %{})
+    tags            = Keyword.get(config, :tags, [])
 
     %{name: name, gl_host: gl_host, host: to_string(hostname), port: port, metadata: metadata, level: level, application: application, socket: socket, compression: compression, tags: tags}
   end


### PR DESCRIPTION
We had an issue on our production environment. gelf_logger was crashing with this error:

```elixir
{:gen_event_EXIT
, {Logger.Backends.Gelf, :gelf_logger}
, {:EXIT, {:function_clause, 
  [{Keyword, :merge, [[], %{}]
  , [file: 'lib/keyword.ex', line: 579]}
  , {Logger.Backends.Gelf, :log_event, 5
  , [file: 'lib/gelf_logger.ex', line: 128]}
  , {Logger.Backends.Gelf, :handle_event, 2
  , [file: 'lib/gelf_logger.ex', line: 88]}
  , {:gen_event, :server_update, 4
  , [file: 'gen_event.erl', line: 533]}
  , {:gen_event, :server_notify, 4
  , [file: 'gen_event.erl', line: 515]}
  , {:gen_event, :handle_msg, 5
  , [file: 'gen_event.erl', line: 256]}
  , {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}]}}}
```
This was happening because we didn't provide `tags` in config.

We believe defaulting the tags to a map is actually causing issues later on when trying to use `Keyword.merge` to merge the list with the default, so this PR should fix it.