### PR TITLE
Use IO.inspect instead of to_string so it immediately works for most data types (eg PIDs)

### DIFF
--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -140,7 +140,7 @@ defmodule Logger.Backends.Gelf do
       md
       |> Keyword.take(state[:metadata])
       |> Keyword.merge(state[:tags])
-      |> Map.new(fn({k,v}) -> {"_#{k}", to_string(v)} end)
+      |> Map.new(fn({k,v}) -> {"_#{k}", IO.inspect(v)} end)
 
     {{year, month, day}, {hour, min, sec, milli}} = ts
 


### PR DESCRIPTION
We are logging PIDs and that doesn't work with `to_string`