### PR TITLE
Fix warnings

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,6 @@
+[
+  inputs: [
+    "lib/**/*.ex",
+    "test/**/*.{ex, exs}",
+  ],
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: elixir
 elixir:
-   - 1.2
    - 1.3
    - 1.4
    - 1.5

--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -60,12 +60,12 @@ defmodule Logger.Backends.Gelf do
   [protofy/erl_graylog_sender](https://github.com/protofy/erl_graylog_sender).
   """
 
-  use GenEvent
-
   @max_size 1047040
   @max_packet_size 8192
   @max_payload_size 8180
   @epoch :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
+
+  # @behaviour :gen_event
 
   def init({__MODULE__, name}) do
     if user = Process.whereis(:user) do

--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -107,7 +107,7 @@ defmodule Logger.Backends.Gelf do
 
     hostname = Keyword.get(config, :hostname, hostname)
 
-    gl_host         = Keyword.get(config, :host) |> to_char_list
+    gl_host         = Keyword.get(config, :host) |> to_charlist
     port            = Keyword.get(config, :port)
     application     = Keyword.get(config, :application)
     level           = Keyword.get(config, :level)
@@ -115,11 +115,11 @@ defmodule Logger.Backends.Gelf do
     compression     = Keyword.get(config, :compression, :gzip)
     tags            = Keyword.get(config, :tags, [])
 
-    port = 
+    port =
       cond do
         is_binary(port) ->
           {val, ""} = Integer.parse(to_string(port))
-          
+
           val
         true ->
           port
@@ -144,12 +144,12 @@ defmodule Logger.Backends.Gelf do
         keys -> Keyword.take(md, keys) # Use only configured metadata keys
       end
       |> Keyword.merge(state[:tags])
-      |> Map.new(fn({k,v}) -> 
+      |> Map.new(fn({k,v}) ->
         case String.Chars.impl_for(v) do
           nil ->
-            {"_#{k}", inspect(v)} 
+            {"_#{k}", inspect(v)}
           _ ->
-            {"_#{k}", to_string(v)} 
+            {"_#{k}", to_string(v)}
         end
       end)
 
@@ -169,7 +169,7 @@ defmodule Logger.Backends.Gelf do
       _application:   state[:application]
     } |> Map.merge(fields)
 
-    data = Poison.encode!(gelf) |> compress(state[:compression])
+    data = Jason.encode!(gelf) |> compress(state[:compression])
 
     size = byte_size(data)
 

--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -60,7 +60,7 @@ defmodule Logger.Backends.Gelf do
   [protofy/erl_graylog_sender](https://github.com/protofy/erl_graylog_sender).
   """
 
-  @max_size 1047040
+  @max_size 1_047_040
   @max_packet_size 8192
   @max_payload_size 8180
   @epoch :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
@@ -88,6 +88,7 @@ defmodule Logger.Backends.Gelf do
     if is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt do
       log_event(level, msg, ts, md, state)
     end
+
     {:ok, state}
   end
 
@@ -103,17 +104,17 @@ defmodule Logger.Backends.Gelf do
 
     {:ok, socket} = :gen_udp.open(0)
 
-    {:ok, hostname} = :inet.gethostname
+    {:ok, hostname} = :inet.gethostname()
 
     hostname = Keyword.get(config, :hostname, hostname)
 
-    gl_host         = Keyword.get(config, :host) |> to_charlist
-    port            = Keyword.get(config, :port)
-    application     = Keyword.get(config, :application)
-    level           = Keyword.get(config, :level)
-    metadata        = Keyword.get(config, :metadata, [])
-    compression     = Keyword.get(config, :compression, :gzip)
-    tags            = Keyword.get(config, :tags, [])
+    gl_host = Keyword.get(config, :host) |> to_charlist
+    port = Keyword.get(config, :port)
+    application = Keyword.get(config, :application)
+    level = Keyword.get(config, :level)
+    metadata = Keyword.get(config, :metadata, [])
+    compression = Keyword.get(config, :compression, :gzip)
+    tags = Keyword.get(config, :tags, [])
 
     port =
       cond do
@@ -121,33 +122,51 @@ defmodule Logger.Backends.Gelf do
           {val, ""} = Integer.parse(to_string(port))
 
           val
+
         true ->
           port
       end
 
-    %{name: name, gl_host: gl_host, host: to_string(hostname), port: port, metadata: metadata, level: level, application: application, socket: socket, compression: compression, tags: tags}
+    %{
+      name: name,
+      gl_host: gl_host,
+      host: to_string(hostname),
+      port: port,
+      metadata: metadata,
+      level: level,
+      application: application,
+      socket: socket,
+      compression: compression,
+      tags: tags
+    }
   end
 
   defp log_event(level, msg, ts, md, state) do
     int_level =
       case level do
         :debug -> 7
-        :info  -> 6
-        :warn  -> 4
+        :info -> 6
+        :warn -> 4
         :error -> 3
       end
 
     fields =
       state[:metadata]
       |> case do
-        :all -> md # Use all metadata
-        keys -> Keyword.take(md, keys) # Use only configured metadata keys
+        # Use all metadata
+        :all ->
+          md
+
+        # Use only configured metadata keys
+        keys ->
+          Keyword.take(md, keys)
       end
       |> Keyword.merge(state[:tags])
-      |> Map.new(fn({k,v}) ->
+      |> Map.new(fn {k, v} ->
         case String.Chars.impl_for(v) do
           nil ->
             {"_#{k}", inspect(v)}
+
           _ ->
             {"_#{k}", to_string(v)}
         end
@@ -155,19 +174,22 @@ defmodule Logger.Backends.Gelf do
 
     {{year, month, day}, {hour, min, sec, milli}} = ts
 
-    epoch_seconds = :calendar.datetime_to_gregorian_seconds({{year, month, day}, {hour, min, sec}}) - @epoch
+    epoch_seconds =
+      :calendar.datetime_to_gregorian_seconds({{year, month, day}, {hour, min, sec}}) - @epoch
 
-    {timestamp, _remainder} = "#{epoch_seconds}.#{milli}" |> Float.parse
+    {timestamp, _remainder} = "#{epoch_seconds}.#{milli}" |> Float.parse()
 
-    gelf = %{
-      short_message:  String.slice(to_string(msg), 0..79),
-      long_message:   to_string(msg),
-      version:        "1.1",
-      host:           state[:host],
-      level:          int_level,
-      timestamp:      Float.round(timestamp, 3),
-      _application:   state[:application]
-    } |> Map.merge(fields)
+    gelf =
+      %{
+        short_message: String.slice(to_string(msg), 0..79),
+        long_message: to_string(msg),
+        version: "1.1",
+        host: state[:host],
+        level: int_level,
+        timestamp: Float.round(timestamp, 3),
+        _application: state[:application]
+      }
+      |> Map.merge(fields)
 
     data = Jason.encode!(gelf) |> compress(state[:compression])
 
@@ -176,11 +198,12 @@ defmodule Logger.Backends.Gelf do
     cond do
       size > @max_size ->
         raise ArgumentError, message: "Message too large"
+
       size > @max_packet_size ->
         num = div(size, @max_packet_size)
 
         num =
-          if (num * @max_packet_size) < size do
+          if num * @max_packet_size < size do
             num + 1
           else
             num
@@ -188,14 +211,24 @@ defmodule Logger.Backends.Gelf do
 
         id = :crypto.strong_rand_bytes(8)
 
-        send_chunks(state[:socket], state[:gl_host], state[:port], data, id, :binary.encode_unsigned(num), 0, size)
+        send_chunks(
+          state[:socket],
+          state[:gl_host],
+          state[:port],
+          data,
+          id,
+          :binary.encode_unsigned(num),
+          0,
+          size
+        )
+
       true ->
         :gen_udp.send(state[:socket], state[:gl_host], state[:port], data)
     end
   end
 
   defp send_chunks(socket, host, port, data, id, num, seq, size) when size > @max_payload_size do
-    <<payload :: binary - size(@max_payload_size), rest :: binary >> = data
+    <<payload::binary-size(@max_payload_size), rest::binary>> = data
 
     :gen_udp.send(socket, host, port, make_chunk(payload, id, num, seq))
 
@@ -209,15 +242,17 @@ defmodule Logger.Backends.Gelf do
   defp make_chunk(payload, id, num, seq) do
     bin = :binary.encode_unsigned(seq)
 
-    << 0x1e, 0x0f, id :: binary - size(8), bin :: binary - size(1), num :: binary - size(1), payload :: binary >>
+    <<0x1E, 0x0F, id::binary-size(8), bin::binary-size(1), num::binary-size(1), payload::binary>>
   end
 
   defp compress(data, type) do
     case type do
       :gzip ->
         :zlib.gzip(data)
+
       :zlib ->
         :zlib.compress(data)
+
       _ ->
         data
     end

--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -95,7 +95,6 @@ defmodule Logger.Backends.Gelf do
   def handle_event(:flush, state) do
     {:ok, state}
   end
-  #:io_reply, ref, msg => handle_io_reply(msg, state)
 
   def handle_info({:io_reply, ref, :ok}, %{ref: ref} = state) do
     Process.demonitor(ref, [:flush])

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GelfLogger.Mixfile do
   def project do
     [app: :gelf_logger,
      version: "0.7.5",
-     elixir: "~> 1.2",
+     elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -30,8 +30,8 @@ defmodule GelfLogger.Mixfile do
 
   defp deps do
    [
-     {:poison, ">= 1.0.0"},
-     {:ex_doc, "~> 0.14", only: :dev}
+     {:jason, "~> 1.0"},
+     {:ex_doc, "~> 0.18", only: :dev}
    ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "poison": {:hex, :poison, "2.0.1", "81248a36d1b602b17ea6556bfa8952492091f01af05173de11f8b297e2bbf088", [:mix], []}}
+%{
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"}
+}

--- a/test/gelf_logger_test.exs
+++ b/test/gelf_logger_test.exs
@@ -6,7 +6,7 @@ defmodule GelfLoggerTest do
 
   Logger.add_backend({Logger.Backends.Gelf, :gelf_logger})
 
-  setup do 
+  setup do
     {:ok, socket} = :gen_udp.open(12201, [:binary, {:active, false}])
 
     {:ok, [socket: socket]}
@@ -16,10 +16,10 @@ defmodule GelfLoggerTest do
     Logger.info "test"
 
     {:ok, {address, _port, packet}} = :gen_udp.recv(context[:socket], 0, 2000)
-    
+
     # Should be coming from localhost
     assert address == {127,0,0,1}
-    
+
     map = process_packet(packet)
 
     assert map["version"] == "1.1"
@@ -127,7 +127,7 @@ defmodule GelfLoggerTest do
     Logger.info "This is a test string that is over eighty characters but only because I kept typing garbage long after I had run out of things to say"
 
     {:ok, {_address, _port, packet}} = :gen_udp.recv(context[:socket], 0, 2000)
-    
+
      map = process_packet(packet)
 
     assert map["short_message"] != map["long_message"]
@@ -151,7 +151,7 @@ defmodule GelfLoggerTest do
 
     map = process_packet(packet)
 
-    assert map["level"] == 6 
+    assert map["level"] == 6
 
     # WARN
     Logger.warn "warn"
@@ -169,12 +169,12 @@ defmodule GelfLoggerTest do
 
     map = process_packet(packet)
 
-    assert map["level"] == 3 
+    assert map["level"] == 3
   end
 
   # The Logger module truncates all messages over 8192 bytes so this can't be tested
   test "should raise error if max message size is exceeded" do
-    # assert_raise(ArgumentError, "Message too large", fn -> 
+    # assert_raise(ArgumentError, "Message too large", fn ->
     #   Logger.info :crypto.rand_bytes(1000000) |> :base64.encode
     # end)
   end
@@ -192,7 +192,7 @@ defmodule GelfLoggerTest do
 
     {:ok, {_address, _port, packet}} = :gen_udp.recv(context[:socket], 0, 2000)
 
-    {:error, _ } = Poison.decode(packet)
+    {:error, _ } = Jason.decode(packet)
 
     map = process_packet(packet)
 
@@ -210,7 +210,7 @@ defmodule GelfLoggerTest do
 
     {:ok, {_address, _port, packet}} = :gen_udp.recv(context[:socket], 0, 2000)
 
-    {:error, _ } = Poison.decode(packet)
+    {:error, _ } = Jason.decode(packet)
 
     map = process_packet(packet)
 
@@ -226,7 +226,7 @@ defmodule GelfLoggerTest do
       _ -> packet
     end
 
-    {:ok,  map} = Poison.decode(data |> to_string)
+    {:ok,  map} = Jason.decode(data |> to_string)
 
     map
   end

--- a/test/gelf_logger_test.exs
+++ b/test/gelf_logger_test.exs
@@ -1,7 +1,7 @@
 defmodule GelfLoggerTest do
   require Logger
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Logger.Backends.Gelf
 
   Logger.add_backend({Logger.Backends.Gelf, :gelf_logger})


### PR DESCRIPTION
Hello,
currently, gelf_logger has a lot of deprecation warnings, so here's a suggestion how to fix it.

Main things that were changed:
- GenEvent replaced with erlang's  :gen_event
- Poison replaced with Jason
- added a default mix formatter

Unfortunately, Jason doesn't support Elixir 1.2 so I've dropped that dependency.

Looking forward to any feedback.

