### PR TITLE
Feature/add formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ current version only supports UDP messages.
 
 In the config.exs, add gelf_logger as a backend like this:
 
-```
+```elixir
 config :logger,
   backends: [:console, {Logger.Backends.Gelf, :gelf_logger}]
 ```
@@ -15,7 +15,7 @@ config :logger,
 In addition, you'll need to pass in some configuration items to the backend
 itself:
 
-```
+```elixir
 config :logger, :gelf_logger,
   host: "127.0.0.1",
   port: 12201,
@@ -23,6 +23,7 @@ config :logger, :gelf_logger,
   compression: :gzip, # Defaults to :gzip, also accepts :zlib or :raw
   metadata: [:request_id, :function, :module, :file, :line],
   hostname: "hostname-override",
+  format: {Module, :function}
   tags: [
     list: "of",
     extra: "tags"

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule GelfLogger.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     elixirc_paths: elixirc_paths(Mix.env()),
      deps: deps(),
      description: description(),
      package: package(),
@@ -20,6 +21,9 @@ defmodule GelfLogger.Mixfile do
      ]
    ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Configuration for the OTP application
   #

--- a/test/support/log_formatter.ex
+++ b/test/support/log_formatter.ex
@@ -1,0 +1,19 @@
+defmodule Test.Support.LogFormatter do
+  @moduledoc """
+  Provides a set of test helping functions for logged message transformation.
+  """
+
+  @doc """
+  Main function of the formatter.
+  """
+  @spec format(atom(), list(), tuple(), list()) :: {atom(), list(), tuple(), list()}
+  def format(level, message, timestamp, metadata) do
+    metadata = add_us_precision_timestamp_to_metadata(metadata)
+    {level, message, timestamp, metadata}
+  end
+
+  # helpers
+  defp add_us_precision_timestamp_to_metadata(metadata) do
+    Keyword.merge(metadata, timestamp_us: :os.system_time(:micro_seconds))
+  end
+end


### PR DESCRIPTION
I needed to be able to use "external" formatter for the message and metadata before sending them to Greylog. I made a short mod in order to be able to use formatter "callback" and I thought other ppl might find it useful too. 