### PR TITLE
Support arbitrary lists in metadata (for Elixir 1.10 support)

### DIFF
--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -228,11 +228,12 @@ defmodule Logger.Backends.Gelf do
           nil ->
             {"_#{k}", inspect(v)}
 
-          String.Chars.List ->
-            {"_#{k}", inspect(v)}
-
           _ ->
-            {"_#{k}", to_string(v)}
+            try do
+              {"_#{k}", to_string(v)}
+            rescue
+              _ -> {"_#{k}", inspect(v)}
+            end
         end
       end)
 

--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -228,6 +228,9 @@ defmodule Logger.Backends.Gelf do
           nil ->
             {"_#{k}", inspect(v)}
 
+          String.Chars.List ->
+            {"_#{k}", inspect(v)}
+
           _ ->
             {"_#{k}", to_string(v)}
         end

--- a/test/gelf_logger_test.exs
+++ b/test/gelf_logger_test.exs
@@ -46,6 +46,15 @@ defmodule GelfLoggerTest do
     assert map["long_message"] == "test"
   end
 
+  test "convert domain from list to binary", context do
+    reconfigure_backend(metadata: :all)
+
+    Logger.info("test")
+    {:ok, {_address, _port, packet}} = :gen_udp.recv(context[:socket], 0, 2000)
+
+    assert %{"_domain" => "[:elixir]"} = process_packet(packet)
+  end
+
   test "configurable source (host)", context do
     reconfigure_backend(hostname: 'host-dev-1')
 


### PR DESCRIPTION
Elixir adds metadata to `Logger` automatically that breaks this library out-of-the-box on Elixir 1.10. It attempts to call `to_string/1` on lists which is no longer supported. I have updated `log_event/5` to now call `inspect/1` on a list instead of `to_string/1`.

For reference, this is the error that pops up when you try to use this library with Elixir 1.10.

```
:gen_event handler {Logger.Backends.Gelf, :gelf_logger} installed in Logger terminating
** (ArgumentError) cannot convert the given list to a string.

To be converted to a string, a list must either be empty or only
contain the following elements:

  * strings
  * integers representing Unicode code points
  * a list containing one of these three elements

Please check the given list or call inspect/1 to get the list representation, got:

[:elixir]
```