### PR TITLE
Replace long_message by full_message

### DIFF
--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -246,7 +246,7 @@ defmodule Logger.Backends.Gelf do
     gelf =
       %{
         short_message: String.slice(to_string(msg_formatted), 0..79),
-        long_message: to_string(msg_formatted),
+        full_message: to_string(msg_formatted),
         version: "1.1",
         host: state[:host],
         level: int_level,

--- a/test/gelf_logger_test.exs
+++ b/test/gelf_logger_test.exs
@@ -28,7 +28,7 @@ defmodule GelfLoggerTest do
     assert map["version"] == "1.1"
     assert map["_application"] == "myapp"
     assert map["short_message"] == "test"
-    assert map["long_message"] == "test"
+    assert map["full_message"] == "test"
   end
 
   test "convert port from binary to integer", context do
@@ -43,7 +43,7 @@ defmodule GelfLoggerTest do
     assert map["version"] == "1.1"
     assert map["_application"] == "myapp"
     assert map["short_message"] == "test"
-    assert map["long_message"] == "test"
+    assert map["full_message"] == "test"
   end
 
   test "configurable source (host)", context do
@@ -111,7 +111,7 @@ defmodule GelfLoggerTest do
     map = process_packet(packet)
 
     assert map["short_message"] == "[info] test"
-    assert map["long_message"] == "[info] test"
+    assert map["full_message"] == "[info] test"
   end
 
   test "skip empty messages", context do
@@ -133,7 +133,7 @@ defmodule GelfLoggerTest do
 
     map = process_packet(packet)
 
-    assert map["short_message"] != map["long_message"]
+    assert map["short_message"] != map["full_message"]
     assert String.length(map["short_message"]) <= 80
   end
 
@@ -195,7 +195,7 @@ defmodule GelfLoggerTest do
 
     map = process_packet(packet)
 
-    assert(map["long_message"] == "test gzip")
+    assert(map["full_message"] == "test gzip")
   end
 
   test "using compression zlib", context do
@@ -209,7 +209,7 @@ defmodule GelfLoggerTest do
 
     map = process_packet(packet)
 
-    assert(map["long_message"] == "test zlib")
+    assert(map["full_message"] == "test zlib")
   end
 
   test "switching JSON encoder", context do
@@ -221,7 +221,7 @@ defmodule GelfLoggerTest do
 
     map = process_packet(packet)
 
-    assert(map["long_message"] == "test different encoder")
+    assert(map["full_message"] == "test different encoder")
   end
 
   test "can use custom formatter", context do
@@ -252,7 +252,7 @@ defmodule GelfLoggerTest do
     map = process_packet(packet)
 
     refute(Map.has_key?(map, "_timestamp_us"))
-    assert(map["long_message"] == "test bad formatter callback")
+    assert(map["full_message"] == "test bad formatter callback")
   end
 
   defp process_packet(packet) do


### PR DESCRIPTION
The Elixir Gelf library sends the field "long_message" to graylog, whereas it should be named "full_message".

https://docs.graylog.org/en/3.2/pages/gelf.html#gelf-payload-specification