### PR TITLE
Add support for Elixir v1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file captures all notable changes to this project.
+
+## Unreleased
+
+- Fix initialization to be compatible with Elixir v1.19 and later
+- Add changelog


### PR DESCRIPTION
Elixir v1.19 deprecates the `config :logger, backends: []` approach for configuring backends.  Instead, it's recommended that backends be configured at runtime in application.ex.  See the following for more details:

- https://github.com/elixir-lang/elixir/blob/v1.19/CHANGELOG.md#logger-1
- https://hexdocs.pm/logger_backends/LoggerBackends.html

This PR updates the gelf_logger's init function to properly handle initialization with the new approach, while remaining backwards compatible.  Also included in this PR is the addition of a CHANGELOG.md file.
